### PR TITLE
PC向けテンプレートのみ存在する画面をスマートフォンで閲覧するとどちらのCSSも適用されない不具合を修正 (fixes #4026)

### DIFF
--- a/lib/event/opThemeEvent.class.php
+++ b/lib/event/opThemeEvent.class.php
@@ -87,11 +87,19 @@ class opThemeEvent
     $assetsType = array('css', 'js');
     foreach ($assetsType as $type)
     {
-      $filePaths = $themeSearcher->findAssetsPathByThemeNameAndType($themeName, $type, $isSmt);
-
-      if (false !== $filePaths)
+      $pcFilePaths = $themeSearcher->findAssetsPathByThemeNameAndType($themeName, $type, false);
+      if (false !== $pcFilePaths)
       {
-        self::includeCssOrJs($filePaths, $type, $isSmt);
+        self::includeCssOrJs($pcFilePaths, $type, false);
+      }
+
+      if ($isSmt)
+      {
+        $smtFilePaths = $themeSearcher->findAssetsPathByThemeNameAndType($themeName, $type, true);
+        if (false !== $smtFilePaths)
+        {
+          self::includeCssOrJs($smtFilePaths, $type, true);
+        }
       }
     }
   }


### PR DESCRIPTION
Bug (バグ) #4026: PC向けのテンプレートのみ存在する画面をスマートフォンで閲覧するとテーマCSSが適用されない
https://redmine.openpne.jp/issues/4026
